### PR TITLE
BUGFIX: Check if iterator has been closed

### DIFF
--- a/Neos.RedirectHandler/Classes/Command/RedirectCommandController.php
+++ b/Neos.RedirectHandler/Classes/Command/RedirectCommandController.php
@@ -120,7 +120,9 @@ class RedirectCommandController extends CommandController
             $redirects = $this->redirectStorage->getAll($host);
         } else {
             $redirects = new \AppendIterator();
-            $redirects->append($this->redirectStorage->getAll(null));
+            if ($this->redirectStorage->getAll(null)->valid() === true) {
+                $redirects->append($this->redirectStorage->getAll(null));
+            }
             foreach ($this->redirectStorage->getDistinctHosts() as $host) {
                 $redirects->append($this->redirectStorage->getAll($host));
             }


### PR DESCRIPTION
Check if iterator has been closed, otherwise no redirects for specific hosts might be added if no redirects valid for all hosts exist
