### PR TITLE
BUGFIX: Check if host is null when hit gets incremented

### DIFF
--- a/Neos.RedirectHandler.DatabaseStorage/Classes/Domain/Repository/RedirectRepository.php
+++ b/Neos.RedirectHandler.DatabaseStorage/Classes/Domain/Repository/RedirectRepository.php
@@ -185,9 +185,8 @@ class RedirectRepository extends Repository
     public function incrementHitCount(RedirectInterface $redirect)
     {
         /** @var Query $query */
-        $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1 WHERE r.sourceUriPath = :sourceUriPath and r.host = :host');
-        $query->setParameter('host', $redirect->getHost())
-            ->setParameters([
+        $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1 WHERE r.sourceUriPath = :sourceUriPath and (r.host = :host or r.host IS NULL)');
+        $query->setParameters([
                 'sourceUriPath' => $redirect->getSourceUriPath(),
                 'host' => $redirect->getHost()
             ])

--- a/Neos.RedirectHandler/Classes/Command/RedirectCommandController.php
+++ b/Neos.RedirectHandler/Classes/Command/RedirectCommandController.php
@@ -288,19 +288,19 @@ class RedirectCommandController extends CommandController
     /**
      * Removes all redirects by host
      *
-     * This command deletes all redirects from the RedirectRepository by host value
-     * by default redirect with NULL host property match all host, until more
-     * specific host can be found.
+     * This command deletes all redirects from the RedirectRepository by host value.
+     * If ``all`` is entered the redirects valid for all hosts are deleted.
      *
-     * @param string $host Full qualified host name
+     * @param string $host Fully qualified host name or `all` to delete redirects valid for all hosts
      * @return void
      */
-    public function removeByHostCommand($host = null)
+    public function removeByHostCommand($host)
     {
-        $this->redirectStorage->removeByHost($host);
-        if ($host === null) {
-            $this->outputLine('Removed all redirects matching all hosts');
+        if ($host === 'all') {
+            $this->redirectStorage->removeByHost(null);
+            $this->outputLine('Removed redirects matching all hosts');
         } else {
+            $this->redirectStorage->removeByHost($host);
             $this->outputLine('Removed all redirects for host "%s"', [$host]);
         }
     }


### PR DESCRIPTION
The update statement missed the `r.host IS NULL` case and would not increment a hit if the host is null.

I also removed the redundant `setParameter` call for the query.
