### PR TITLE
BUGFIX: Check if host is null when hit gets incremented

### DIFF
--- a/Neos.RedirectHandler.DatabaseStorage/Classes/Domain/Repository/RedirectRepository.php
+++ b/Neos.RedirectHandler.DatabaseStorage/Classes/Domain/Repository/RedirectRepository.php
@@ -184,12 +184,15 @@ class RedirectRepository extends Repository
      */
     public function incrementHitCount(RedirectInterface $redirect)
     {
+        $host = $redirect->getHost();
         /** @var Query $query */
-        $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1 WHERE r.sourceUriPath = :sourceUriPath and (r.host = :host or r.host IS NULL)');
-        $query->setParameters([
-                'sourceUriPath' => $redirect->getSourceUriPath(),
-                'host' => $redirect->getHost()
-            ])
+        if ($host === null) {
+            $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1 WHERE r.sourceUriPath = :sourceUriPath and r.host IS NULL');
+        } else {
+            $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1 WHERE r.sourceUriPath = :sourceUriPath and r.host = :host');
+            $query->setParameter('host', $host);
+        }
+        $query->setParameter('sourceUriPath', $redirect->getSourceUriPath())
             ->execute();
     }
 

--- a/Neos.RedirectHandler.DatabaseStorage/Classes/Domain/Repository/RedirectRepository.php
+++ b/Neos.RedirectHandler.DatabaseStorage/Classes/Domain/Repository/RedirectRepository.php
@@ -185,9 +185,8 @@ class RedirectRepository extends Repository
     public function incrementHitCount(RedirectInterface $redirect)
     {
         /** @var Query $query */
-        $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1 WHERE r.sourceUriPath = :sourceUriPath and r.host = :host');
-        $query->setParameter('host', $redirect->getHost())
-            ->setParameters([
+        $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1 WHERE r.sourceUriPath = :sourceUriPath and (r.host = :host or r.host IS NULL)');
+        $query->setParameters([
                 'sourceUriPath' => $redirect->getSourceUriPath(),
                 'host' => $redirect->getHost()
             ])


### PR DESCRIPTION
Added `r.host IS NULL` case to update statement, otherwise hit would not be incremented if the host is null. 

Also removed the obsolete `setParameter`call, as the parameter is added via 'setParameters' below.

(Recreated PR, after i messed up the old one)
