### PR TITLE
BUGFIX: Do not add ```null`` to hosts array for ``list`` command

### DIFF
--- a/Neos.RedirectHandler/Classes/Command/RedirectCommandController.php
+++ b/Neos.RedirectHandler/Classes/Command/RedirectCommandController.php
@@ -97,7 +97,7 @@ class RedirectCommandController extends CommandController
         if ($host !== null) {
             $outputByHost($host);
         } else {
-            $hosts = array_merge([null], $this->redirectStorage->getDistinctHosts());
+            $hosts = $this->redirectStorage->getDistinctHosts();
             array_map($outputByHost, $hosts);
         }
         $this->outputLine();


### PR DESCRIPTION
Since the storage now also returns hosts with the value `null`, those hosts would be listed twice without this change.
